### PR TITLE
Develop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,37 @@
-# Stage 1: Build Stage
+# ---------- Build Stage ----------
 ARG PYTHON_VERSION=3.8
-FROM python:${PYTHON_VERSION} as builder
-
-# Set the working directory
-WORKDIR /app
-COPY . .
-
-# Stage 2: Run Stage
-FROM python:${PYTHON_VERSION} as run
+FROM python:${PYTHON_VERSION} AS base
 
 WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --upgrade pip && pip install -r requirements.txt
+
+# ---------- Run Stage ----------
+FROM python:${PYTHON_VERSION}-slim
+
+COPY --from=base /usr/local /usr/local
+
+# Installing netcat for startup script and clearing apt cache:
+# netcat is used to guarantee that db connection is established 
+# befor applying initial migration
+RUN apt-get update && \
+    apt-get install -y netcat-openbsd && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONUNBUFFERED=1
 
-COPY --from=builder /app .
+WORKDIR /app
 
-RUN pip install --upgrade pip && \
-    pip install -r requirements.txt
+COPY accounts ./accounts
+COPY api ./api
+COPY lists ./lists
+COPY todolist ./todolist
+COPY manage.py ./
+COPY entrypoint.sh /entrypoint.sh
 
-RUN python manage.py migrate
+RUN chmod +x /entrypoint.sh
 
 EXPOSE 8080
 
-# Run database migrations and start the Django application
-ENTRYPOINT ["python", "manage.py", "runserver", "0.0.0.0:8080"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile.mysql
+++ b/Dockerfile.mysql
@@ -12,3 +12,5 @@ EXPOSE 3306
 
 # Set the data directory as a volume
 VOLUME /var/lib/mysql
+
+COPY init.sql /docker-entrypoint-initdb.d/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+networks:
+  db-data-net:
+    driver: bridge
+services:
+  mysql:
+   image: my-sql:1.2
+   build:
+     context: .
+     dockerfile: Dockerfile.mysql
+   container_name: my-sql 
+   ports:
+     - "3306:3306"
+   volumes:
+     - db-data:/var/lib/mysql
+   environment:
+     - MYSQL_ROOT_PASSWORD=1234
+     - MYSQL_DATABASE=app_db
+     - MYSQL_USER=app_user
+     - MYSQL_PASSWORD=1234
+   networks:
+     - db-data-net
+  pythonapp:
+   image: todoapp:2.0.0
+   build:
+     context: .
+     dockerfile: Dockerfile
+   ports:
+     - "8080:8000"
+   environment:
+     - MYSQL_ROOT_PASSWORD=1234
+     - MYSQL_PASSWORD=1234
+     - MYSQL_HOST=mysql
+     - MYSQL_DATABASE=app_db
+     - MYSQL_USER=app_user
+   networks:
+     - db-data-net
+   depends_on:
+     - mysql
+   restart: unless-stopped
+volumes:
+  db-data:

--- a/todolist/settings.py
+++ b/todolist/settings.py
@@ -63,8 +63,8 @@ WSGI_APPLICATION = "todolist.wsgi.application"
 DATABASES = {
     'default': {
         'ENGINE': 'mysql.connector.django',
-        'NAME': 'app_db', # Avoid changing db name
-        'USER': 'app_user', # user is created with db and init.sql grants its all priviledges, avoid changing it
+        'NAME': os.getenv('MYSQL_DATABASE', 'localhost'),
+        'USER': os.getenv('MYSQL_USER', 'localhost'), 
         'PASSWORD': os.getenv('MYSQL_PASSWORD', '1234'),
         'HOST': os.getenv('MYSQL_HOST', 'localhost'),
         'PORT': os.getenv('MYSQL_PORT', '3306'),

--- a/todolist/settings.py
+++ b/todolist/settings.py
@@ -63,12 +63,12 @@ WSGI_APPLICATION = "todolist.wsgi.application"
 DATABASES = {
     'default': {
         'ENGINE': 'mysql.connector.django',
-        'NAME': 'app_db',
-        'USER': 'app_user',
-        'PASSWORD': '1234',
-        'HOST': '172.17.0.2',  # You can use a different host if your MySQL server is on a remote machine.
-        'PORT': '',  # Leave this empty to use the default MySQL port (3306).
-    }
+        'NAME': 'app_db', # Avoid changing db name
+        'USER': 'app_user', # user is created with db and init.sql grants its all priviledges, avoid changing it
+        'PASSWORD': os.getenv('MYSQL_PASSWORD', '1234'),
+        'HOST': os.getenv('MYSQL_HOST', 'localhost'),
+        'PORT': os.getenv('MYSQL_PORT', '3306'),
+        }
 }
 
 # Internationalization


### PR DESCRIPTION
These tasks:
2. Remove RUN python manage.py migrate as the database is no longer available at the build time
3. Refactor ENTRYPOINT to execute both db migration and application start. Example:
`ENTRYPOINT ["sh", "-c", “command1 && command2”]`
were refactored to startup script `entrypoint.sh` which also makes an app to wait untill the connection to db is established.